### PR TITLE
🐛 Fix : oauth의 경우 password 검증 페이지를 따로 넣지 않음!

### DIFF
--- a/src/component/BlueButton.js
+++ b/src/component/BlueButton.js
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import "./css/rainbow.css";
 
 
 export default function BlueButton({ 

--- a/src/users/components/common/UserRoleInfo.js
+++ b/src/users/components/common/UserRoleInfo.js
@@ -73,6 +73,12 @@ function UserInfo() {
     const handlePasswordVerification = (isValid) => {
       setIsPasswordVerified(isValid);
     };
+
+    useEffect(() => {
+        if (localStorage.getItem("PROVIDER")) {
+            setIsPasswordVerified(true);
+        }
+    }, []);
   
     return (
       <Container>

--- a/src/users/views/ModifyView.js
+++ b/src/users/views/ModifyView.js
@@ -127,7 +127,7 @@ export default function ModifyView(userInfo) {
                       onClick={openDaumPostcode}
                       className='modify-input-box'
                     >
-                      우편번호 찾기
+                      찾기
                     </PostcodeButton>
                   </Box>
                 </Grid>


### PR DESCRIPTION
# 2NY - Frontend
# 🐛 Fix : oauth의 경우 password 검증 페이지를 따로 넣지 않음!

- password 검증 페이지를 따로 넣지 않도록 수정

💄Style: 파란 버튼 이미지 바꿈

![image](https://github.com/user-attachments/assets/eceb9d3c-2b24-4e5c-9a56-65588f1dc939)
